### PR TITLE
[domains] Move domain_creation routine to the separate header

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,9 @@ target_sources_ifdef(CONFIG_SOC_SERIES_RCAR_GEN4 app PRIVATE src/domains/domd/do
 # Gen3 specific binaries were added with separate .S file to avoid extra checks inside source files.
 target_sources_ifdef(CONFIG_BOARD_RCAR_SALVATOR_XS_M3_2X4G app PRIVATE src/domains/domd/domd_cfg_gen3.c src/domains/domd/domain_bins_gen3.S)
 
+# NOTE: Include source files for xenvm boards.
+target_sources_ifdef(CONFIG_BOARD_XENVM app PRIVATE src/domains/domd/domd_cfg_xenvm.c)
+
 # ######################################################################################################################
 # Versioning
 # ######################################################################################################################

--- a/src/domains/dom_runner.h
+++ b/src/domains/dom_runner.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2023 Renesas Electronics Corporation.
+ * Copyright (C) 2023 EPAM Systems, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef DOMAIN_CONF_H_
+#define DOMAIN_C0NF_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern struct xen_domain_cfg domd_cfg;
+
+int create_domains();
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* DOMAIN_CONF_H_ */

--- a/src/domains/domd/domd_cfg_gen3.c
+++ b/src/domains/domd/domd_cfg_gen3.c
@@ -6,7 +6,10 @@
 
 #include <domain.h>
 #include <string.h>
+#include <xen_dom_mgmt.h>
 #include <zephyr/xen/public/domctl.h>
+
+#include <domains/dom_runner.h>
 
 static char* domd_dtdevs[] = {
     "/soc/ethernet@e6800000",
@@ -539,4 +542,9 @@ struct xen_domain_cfg domd_cfg = {
 
     .dtb_start = __dtb_ipl_start,
     .dtb_end = __dtb_ipl_end,
+};
+
+int create_domains(void)
+{
+    return domain_create(&domd_cfg, 1);
 };

--- a/src/domains/domd/domd_cfg_spider.c
+++ b/src/domains/domd/domd_cfg_spider.c
@@ -6,7 +6,10 @@
 
 #include <domain.h>
 #include <string.h>
+#include <xen_dom_mgmt.h>
 #include <zephyr/xen/public/domctl.h>
+
+#include <domains/dom_runner.h>
 
 static char* domd_dtdevs[] = {
     "/soc/dma-controller@e7350000",
@@ -290,4 +293,9 @@ struct xen_domain_cfg domd_cfg = {
 
     .dtb_start = __dtb_ipl_start,
     .dtb_end = __dtb_ipl_end,
+};
+
+int create_domains(void)
+{
+    return domain_create(&domd_cfg, 1);
 };

--- a/src/domains/domd/domd_cfg_xenvm.c
+++ b/src/domains/domd/domd_cfg_xenvm.c
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2023 EPAM Systems
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <domain.h>
+#include <domains/dom_runner.h>
+
+struct xen_domain_cfg domd_cfg;
+
+int create_domains(void)
+{
+    return 0;
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,17 +15,9 @@
 #include "logger/logger.hpp"
 #include "version.hpp"
 
-#if defined(CONFIG_SOC_SERIES_RCAR_GEN4) || defined(CONFIG_SOC_SERIES_RCAR_GEN3)
-extern "C" {
-#include <xen_dom_mgmt.h>
-
-extern struct xen_domain_cfg domd_cfg;
-}
-#elif !defined(CONFIG_NATIVE_APPLICATION)
-/* NOTE: add empty domd_cfg function because it's used in xen_cmds to prevent breaking the build */
-#include <domain.h>
-struct xen_domain_cfg domd_cfg;
-#endif /* CONFIG_SOC_SERIES_RCAR_GEN4 || CONFIG_SOC_SERIES_RCAR_GEN3 */
+#if !defined(CONFIG_NATIVE_APPLICATION)
+#include <domains/dom_runner.h>
+#endif
 
 int main(void)
 {
@@ -33,12 +25,12 @@ int main(void)
     printk("*** Aos core library: %s ***\n", AOS_CORE_VERSION);
     printk("*** Aos core size: %lu ***\n", sizeof(App));
 
-#if defined(CONFIG_SOC_SERIES_RCAR_GEN4) || defined(CONFIG_SOC_SERIES_RCAR_GEN3)
-    int rc = domain_create(&domd_cfg, 1);
+#if !defined(CONFIG_NATIVE_APPLICATION)
+    auto rc = create_domains();
     if (rc) {
         printk("failed to create domain (%d)\n", rc);
     }
-#endif /* CONFIG_SOC_SERIES_RCAR_GEN4 || CONFIG_SOC_SERIES_RCAR_GEN3 */
+#endif
 
     Logger::Init();
 


### PR DESCRIPTION
It appears that domains configuration is not common for rcar, qemu and native builds. We need to provide common api for all configurations, such as:
- for RCAR boards - domd should be started.
- for QEMU no need to start domains on init, but allocate dummy domd_cfg to avoid compilation errors in xen_cmds.
- for NATIVE and QEMU builds create_domains call should be dummy.