### PR TITLE
WA: Disable MMC DMA support to avoid using z_mem_phys_addr

### DIFF
--- a/prj.conf
+++ b/prj.conf
@@ -110,6 +110,9 @@ CONFIG_FLASH_SHELL=y
 CONFIG_FLASH_SIMULATOR=y
 CONFIG_FLASH_MAP=y
 
+# WA: Disable MMC_DMA to avoid z_mem_phys_add assertion
+CONFIG_RCAR_MMC_DMA_SUPPORT=n
+
 # ######################################################################################################################
 # Xen and its components
 # ######################################################################################################################


### PR DESCRIPTION
There is a generic problem with Zephyr memory subsystem when dealing with Xen Extended regions driver. z_mem_phys_addr call has the following code:

__ASSERT((addr >= CONFIG_KERNEL_VM_BASE) &&
		 (addr < (CONFIG_KERNEL_VM_BASE +
			  (CONFIG_KERNEL_VM_SIZE))),
		 "address %p not in permanent mappings", virt);

which will fail if address was allocated outside of kernel memory. Exteded regions driver is using memory, defined by XEN as extended and lays outside of Zephyr kernel memory. The problem is that z_mem_phys_addr doesn't know about the allocator so disable DMA to avoid z_mem_phys_addr call in MMC driver.