### PR TITLE
[domd] set explicit machine_dt_compat for spider

### DIFF
--- a/src/domains/domd/domd_cfg_spider.c
+++ b/src/domains/domd/domd_cfg_spider.c
@@ -268,6 +268,7 @@ static ssize_t get_ipl_image_size(void* image_info, uint64_t* size)
 }
 
 struct xen_domain_cfg domd_cfg = {
+    .machine_dt_compat = "renesas,r8a779f0",
     .mem_kb = 0x100000, /* 1Gb */
 
     .flags = (XEN_DOMCTL_CDF_hvm | XEN_DOMCTL_CDF_hap | XEN_DOMCTL_CDF_iommu),


### PR DESCRIPTION
Set explicit machine_dt_compat for spider boards,
to enable the correct initialization for platform.