### PR TITLE
config: Move cmdline config to domain.cfg

### DIFF
--- a/src/domains/domd/domd_cfg_h3ulcb.c
+++ b/src/domains/domd/domd_cfg_h3ulcb.c
@@ -505,6 +505,10 @@ struct xen_domain_cfg domd_cfg = {
     .load_image_bytes  = load_ipl_image,
     .get_image_size    = get_ipl_image_size,
     .image_info        = NULL,
+    .cmdline
+    = "root=/dev/mmcblk1p4 ro rootwait console=hvc0 clk_ignore_unused pci=pcie_bus_perf vardir.disk=/dev/mmcblk1p5 "
+      "opendisk.target=/dev/mmcblk1p6 opendisk.pkcs11=optee aosupdate.disk=/dev/aosvg/workdirs "
+      "aosupdate.path=um/update_rootfs aosupdate.selinux_module=/usr/share/selinux/aos/base.pp",
 
     .dtb_start = __dtb_ipl_start,
     .dtb_end   = __dtb_ipl_end,

--- a/src/domains/domd/domd_cfg_salvator_xs.c
+++ b/src/domains/domd/domd_cfg_salvator_xs.c
@@ -527,6 +527,10 @@ struct xen_domain_cfg domd_cfg = {
     .load_image_bytes  = load_ipl_image,
     .get_image_size    = get_ipl_image_size,
     .image_info        = NULL,
+    .cmdline
+    = "root=/dev/mmcblk1p4 ro rootwait console=hvc0 clk_ignore_unused pci=pcie_bus_perf vardir.disk=/dev/mmcblk1p5 "
+      "opendisk.target=/dev/mmcblk1p6 opendisk.pkcs11=optee aosupdate.disk=/dev/aosvg/workdirs "
+      "aosupdate.path=um/update_rootfs aosupdate.selinux_module=/usr/share/selinux/aos/base.pp",
 
     .dtb_start = __dtb_ipl_start,
     .dtb_end   = __dtb_ipl_end,

--- a/src/domains/domd/domd_cfg_spider.c
+++ b/src/domains/domd/domd_cfg_spider.c
@@ -309,6 +309,9 @@ struct xen_domain_cfg domd_cfg = {
     .load_image_bytes  = load_ipl_image,
     .get_image_size    = get_ipl_image_size,
     .image_info        = NULL,
+    .cmdline = "root=/dev/sda4 ro rootwait console=hvc0 clk_ignore_unused pci=pcie_bus_perf vardir.disk=/dev/sda5 "
+               "opendisk.target=/dev/sda6 opendisk.pkcs11=optee aosupdate.disk=/dev/aosvg/workdirs "
+               "aosupdate.path=um/update_rootfs aosupdate.selinux_module=/usr/share/selinux/aos/base.pp",
 
     .dtb_start = __dtb_ipl_start,
     .dtb_end   = __dtb_ipl_end,


### PR DESCRIPTION
Move cmdline configuration from u-boot to domain.cfg. This will allow for each domain to have its own cmdline configuration.