### PR TITLE
domains: domd: fix initializer of machine_dt_compat field in domd_cfg

### DIFF
--- a/src/domains/domd/domd_cfg_spider.c
+++ b/src/domains/domd/domd_cfg_spider.c
@@ -283,7 +283,8 @@ static ssize_t get_ipl_image_size(void* image_info, uint64_t* size)
 }
 
 struct xen_domain_cfg domd_cfg = {
-    .machine_dt_compat = "renesas,r8a779f0",
+    .machine_dt_compat    = (const char*[]) {"renesas,r8a779f0"},
+    .nr_machine_dt_compat = 1,
     .mem_kb            = 0x100000, /* 1Gb */
 
     .flags               = (XEN_DOMCTL_CDF_hvm | XEN_DOMCTL_CDF_hap | XEN_DOMCTL_CDF_iommu),


### PR DESCRIPTION
Change the initializer of machine_dt_compat field from a single string to an array of strings to match its updated type.