### PR TITLE
Move hypervisor and ram nodes to boards overlays

### DIFF
--- a/boards/rcar_h3ulcb_ca57.overlay
+++ b/boards/rcar_h3ulcb_ca57.overlay
@@ -9,6 +9,7 @@
 
 /delete-node/ &sd0;
 /delete-node/ &gpio5;
+/delete-node/ &ram;
 
 &emmc2 {
 	disk {
@@ -17,11 +18,40 @@
 	status = "okay";
 };
 
-&ram {
-	reg = <0x00 0x70000000 0x00 DT_SIZE_M(256)>;
-};
-
 / {
+	/*
+	 * This node may differs on different setups, please check
+	 * following line in Xen boot log to set it right:
+	 * (XEN) Grant table range: 0x00000088080000-0x000000880c0000
+	 * Also, add extended region 2:
+	 * (XEN) [    0.928173] d0: extended region 2: 0x40000000->0x47e00000
+	 *
+	 * Xen passes actual values for setup in domain device tree, but Zephyr
+	 * is not capable to parse and handle it in runtime.
+	 */
+	hypervisor: hypervisor@88080000 {
+		compatible = "xen,xen";
+		reg = <0x0 0x88080000 0x0 0x40000 0x0 0x40000000 0x0 0x7e00000>;
+		interrupts = <GIC_PPI 0x0 IRQ_TYPE_EDGE IRQ_DEFAULT_PRIORITY>;
+		interrupt-parent = <&gic>;
+		status = "okay";
+	};
+
+	/*
+	 * This node may differs on different setups, because Xen picks
+	 * region for Domain-0 for every specific configuration. You can
+	 * start Xen for your platform and check following log:
+	 * (XEN) Allocating 1:1 mappings for dom0:
+	 * (XEN) BANK[0] 0x00000070000000-0x00000080000000 (256MB)
+	 *
+	 * Xen passes actual values for setup in domain device tree, but Zephyr
+	 * is not capable to parse and handle it in runtime.
+	 */
+	ram: memory@70000000 {
+		device_type = "mmio-sram";
+		reg = <0x00 0x70000000 0x00 DT_SIZE_M(256)>;
+	};
+
 	firmware {
 		tee {
 		compatible = "linaro,optee-tz";

--- a/boards/rcar_salvator_xs_m3.overlay
+++ b/boards/rcar_salvator_xs_m3.overlay
@@ -7,6 +7,8 @@
 
 #include <mem.h>
 
+/delete-node/ &ram;
+
 &emmc2 {
 	disk {
 		status = "okay";
@@ -14,11 +16,40 @@
 	status = "okay";
 };
 
-&ram {
-	reg = <0x00 0x70000000 0x00 DT_SIZE_M(256)>;
-};
-
 / {
+	/*
+	 * This node may differs on different setups, please check
+	 * following line in Xen boot log to set it right:
+	 * (XEN) Grant table range: 0x00000088080000-0x000000880c0000
+	 * Also, add extended region 2:
+	 * (XEN) [    0.928173] d0: extended region 2: 0x40000000->0x47e00000
+	 *
+	 * Xen passes actual values for setup in domain device tree, but Zephyr
+	 * is not capable to parse and handle it in runtime.
+	 */
+	hypervisor: hypervisor@88080000 {
+		compatible = "xen,xen";
+		reg = <0x0 0x88080000 0x0 0x40000 0x0 0x40000000 0x0 0x7e00000>;
+		interrupts = <GIC_PPI 0x0 IRQ_TYPE_EDGE IRQ_DEFAULT_PRIORITY>;
+		interrupt-parent = <&gic>;
+		status = "okay";
+	};
+
+	/*
+	 * This node may differs on different setups, because Xen picks
+	 * region for Domain-0 for every specific configuration. You can
+	 * start Xen for your platform and check following log:
+	 * (XEN) Allocating 1:1 mappings for dom0:
+	 * (XEN) BANK[0] 0x00000070000000-0x00000080000000 (256MB)
+	 *
+	 * Xen passes actual values for setup in domain device tree, but Zephyr
+	 * is not capable to parse and handle it in runtime.
+	 */
+	ram: memory@70000000 {
+		device_type = "mmio-sram";
+		reg = <0x00 0x70000000 0x00 DT_SIZE_M(256)>;
+	};
+
 	firmware {
 		tee {
 		compatible = "linaro,optee-tz";

--- a/boards/rcar_spider_ca55.overlay
+++ b/boards/rcar_spider_ca55.overlay
@@ -7,6 +7,8 @@
 
 #include <mem.h>
 
+/delete-node/ &ram;
+
 &mmc0 {
 	disk {
 		status = "okay";
@@ -15,6 +17,39 @@
 };
 
 / {
+	/*
+	 * This node may differs on different setups, please check
+	 * following line in Xen boot log to set it right:
+	 * (XEN) Grant table range: 0x00000078080000-0x000000780c0000
+	 * Also, add extended region 1:
+	 * (XEN) Extended region 1: 0x40000000->0x47e00000
+	 *
+	 * Xen passes actual values for setup in domain device tree, but Zephyr
+	 * is not capable to parse and handle it in runtime.
+	 */
+	hypervisor: hypervisor@78080000 {
+		compatible = "xen,xen";
+		reg = <0x0 0x78080000 0x0 0x40000 0x0 0x40000000 0x0 0x7e00000>;
+		interrupts = <GIC_PPI 0x0 IRQ_TYPE_EDGE IRQ_DEFAULT_PRIORITY>;
+		interrupt-parent = <&gic>;
+		status = "okay";
+	};
+
+	/*
+	 * This node may differs on different setups, because Xen picks
+	 * region for Domain-0 for every specific configuration. You can
+	 * start Xen for your platform and check following log:
+	 * (XEN) Allocating 1:1 mappings for dom0:
+	 * (XEN) BANK[0] 0x00000080000000-0x00000090000000 (256MB)
+	 *
+	 * Xen passes actual values for setup in domain device tree, but Zephyr
+	 * is not capable to parse and handle it in runtime.
+	 */
+	ram: memory@80000000 {
+		device_type = "mmio-sram";
+		reg = <0x00 0x80000000 0x00 DT_SIZE_M(256)>;
+	};
+
 	firmware {
 		tee {
 		compatible = "linaro,optee-tz";


### PR DESCRIPTION
In zephyr v3.6.0 for Dom0 enabling we use snippets. They were also used for hypervisor and ram nodes creation. But since snippets are applied in the end of device tree generation, they are not suitable for these purposes.